### PR TITLE
Ignore subsequent routes after .preventDefault()

### DIFF
--- a/src/grapnel.js
+++ b/src/grapnel.js
@@ -125,7 +125,7 @@
             // If action is instance of RegEx, match the action
             var match = self.anchor.get().match(regex);
             // Test matches against current action
-            if(match){
+            if(match && (!self.state || self.state.propagateEvent !== false)) {
                 // Match found
                 var req = { params : {}, keys : keys, matches : match.slice(1) };
                 // Build parameters


### PR DESCRIPTION
New to Grapnel but impressed with the functionality so far. I've added the ability to do something like this, which some other routing libraries support in varying formats and can be very useful:

```js
var router = new Grapnel();

router.get('api/*', function(req, e) {
    if(!isAuthorized) e.preventDefault();
});

router.get('api/secret', function(req) {
    // Authorized users only!
});
```

I'm undecided on whether the use of `preventDefault` is inappropriate for this behavior, I'm happy to change it to a new method or simply `return false` if that would be clearer. `return false` would more likely be a breaking change.