### PR TITLE
Adding IE8 support and fixing Require JS optimiser compatibility

### DIFF
--- a/src/grapnel.js
+++ b/src/grapnel.js
@@ -14,6 +14,22 @@
     function Grapnel(opts){
         "use strict";
 
+        if (!Object.keys) {
+            // IE8 polyfill
+            Object.keys = function(o, k, r) {
+                r = [];
+                for (k in o) {
+                    r.hasOwnProperty.call(o, k) && r.push(k);
+                }
+                return r;
+            };
+        }
+        if (!Date.now) {
+            Date.now = function() {
+                return new Date().getTime();
+            };
+        }
+
         var self = this; // Scope reference
         this.events = {}; // Event Listeners
         this.state = null; // Router state object
@@ -32,6 +48,12 @@
                 if(self.state && self.state.previousState === null) return false;
                 
                 self.trigger('navigate');
+            });
+        }
+        else if ('object' === typeof root.attachEvent) {
+            // IE8 support
+            root.attachEvent('onhashchange', function () {
+                self.trigger('hashchange');
             });
         }
         /**
@@ -293,7 +315,7 @@
     */
     Grapnel.prototype.navigate = function(path){
         return this.fragment.set(path).trigger('navigate');
-    }
+    };
     /**
      * Create routes based on an object
      *

--- a/src/grapnel.js
+++ b/src/grapnel.js
@@ -342,9 +342,9 @@
         }).call(new Grapnel(opts || {}));
     }
 
-    if('function' === typeof root.define && !root.define.amd.grapnel){
-        root.define(function(require, exports, module){
-            root.define.amd.grapnel = true;
+    if('function' === typeof define && !define.amd.grapnel){
+        define(function(require, exports, module){
+            define.amd.grapnel = true;
             return Grapnel;
         });
     }else if('object' === typeof module && 'object' === typeof module.exports){


### PR DESCRIPTION
Hey Greg

Thanks for your great work on Grapnel JS, we've started using it for one of our projects and it's doing the job nicely for us.

We were previously using the library from NPM, but it was missing 2 features we really need. One of these is IE8 support, and the other is compatibility with the Require JS optimiser (r.js). So in the mean time we're referencing the library locally.

Instead of asking you to add this features, we've created a fork and implemented them there. It would be great if you could incorporate these, so that we could reference Grapnel from NPM and have all those benefits again.

Looking forward to your feedback

Thanks!